### PR TITLE
ci: Trusted Publishing으로 npm publish 전환

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -42,6 +45,4 @@ jobs:
 
       - name: Publish
         if: steps.version.outputs.changed == 'true'
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance


### PR DESCRIPTION
## Summary

- npm publish 방식을 NPM_TOKEN 시크릿에서 Trusted Publishing(OIDC)으로 전환
- 토큰 유출 위험 제거, 단기 OIDC 토큰 자동 발급/만료
- `--provenance` 플래그로 소스 출처 증명 포함

## 변경 사항

- `permissions.id-token: write` 추가
- `NODE_AUTH_TOKEN` env 제거
- `npm publish --provenance` 사용

## Test plan

- [ ] main 머지 후 GitHub Actions에서 v0.1.1 자동 publish 확인
- [ ] `npx parrotube@0.1.1 --help` 정상 동작 확인


Made with [Cursor](https://cursor.com)