### PR TITLE
fix: Trusted Publishing .npmrc 충돌 해결

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       - run: npm install
       - run: npm run build
@@ -34,7 +33,7 @@ jobs:
         id: version
         run: |
           LOCAL=$(node -p "require('./package.json').version")
-          REMOTE=$(npm view parrotube version 2>/dev/null || echo "0.0.0")
+          REMOTE=$(npm view parrotube version --registry https://registry.npmjs.org 2>/dev/null || echo "0.0.0")
           echo "local=$LOCAL" >> $GITHUB_OUTPUT
           echo "remote=$REMOTE" >> $GITHUB_OUTPUT
           if [ "$LOCAL" != "$REMOTE" ]; then
@@ -45,4 +44,4 @@ jobs:
 
       - name: Publish
         if: steps.version.outputs.changed == 'true'
-        run: npm publish --provenance
+        run: npm publish --provenance --access public --registry https://registry.npmjs.org


### PR DESCRIPTION
## Summary

- `actions/setup-node`의 `registry-url` 옵션이 `.npmrc`에 `NODE_AUTH_TOKEN` 플레이스홀더를 생성하여 OIDC 인증을 방해하는 문제 수정
- `registry-url` 제거, `npm publish`에 `--registry` 직접 지정

## Test plan

- [ ] main 머지 후 v0.1.1 자동 publish 성공 확인


Made with [Cursor](https://cursor.com)