### PR TITLE
fix: Trusted Publishing npm 버전 업그레이드

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
+      - run: npm install -g npm@latest
       - run: npm install
       - run: npm run build
 
@@ -44,4 +46,4 @@ jobs:
 
       - name: Publish
         if: steps.version.outputs.changed == 'true'
-        run: npm publish --provenance --access public --registry https://registry.npmjs.org
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Node 22 번들 npm (10.x)은 OIDC Trusted Publishing을 지원하지 않아 `ENEEDAUTH` 발생
- `npm install -g npm@latest`로 npm 11.5.1+ 설치하여 OIDC 지원 활성화
- `registry-url` 복원 → `.npmrc` 생성 → npm이 OIDC 토큰으로 자동 인증

## Root Cause
Trusted Publishing은 npm >= 11.5.1이 필요하지만, `actions/setup-node`의 Node 22는 npm 10.x를 번들

## Test plan
- [ ] main 머지 후 GitHub Actions publish job 성공 확인

Made with [Cursor](https://cursor.com)