### PR TITLE
fix: auth 완료 후 프로세스가 종료되지 않는 버그 수정

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -93,6 +93,7 @@ function listenForCode(port: number): Promise<string> {
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end('<h1>Authentication successful!</h1><p>You can close this tab.</p>');
         server.close();
+        server.closeAllConnections();
         resolve(code);
       } else {
         res.writeHead(400);


### PR DESCRIPTION
## Summary

- `listenForCode()`에서 OAuth2 콜백 수신 후 `server.closeAllConnections()` 호출 추가
- `server.close()`만으로는 기존 keep-alive 연결이 유지되어 Node.js 이벤트 루프가 종료되지 않는 문제 해결

## Changes

- `src/auth.ts`: `server.close()` 직후 `server.closeAllConnections()` 1줄 추가 (Node 18.2+)

## Test

- [x] `bun test` 43개 전체 통과

Resolved #7

Made with [Cursor](https://cursor.com)