### PR TITLE
feat: YouTube 영상 자막 텍스트 추출 (data:transcript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,21 @@ List captions for a video.
 parrotube data:captions --video-id dQw4w9WgXcQ
 ```
 
+### data:transcript
+
+Extract transcript (subtitles/captions text) from any public video, including auto-generated captions. Does not require video ownership — works with any public video.
+
+```bash
+# JSON output with timestamps
+parrotube data:transcript --video-id dQw4w9WgXcQ
+
+# Specific language
+parrotube data:transcript --video-id dQw4w9WgXcQ --lang ko
+
+# Plain text only (no timestamps)
+parrotube data:transcript --video-id dQw4w9WgXcQ --format text
+```
+
 ### data:categories
 
 Fetch video categories for a region.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -33,12 +33,12 @@ describe('CLI program', () => {
     expect(help).toContain('--format');
   });
 
-  test('서브커맨드 25개 등록 (analytics + data api)', async () => {
+  test('서브커맨드 26개 등록 (analytics + data api)', async () => {
     const { createProgram } = await import('./index');
     const program = createProgram();
 
     const commandNames = program.commands.map((c) => c.name());
-    expect(commandNames).toHaveLength(25);
+    expect(commandNames).toHaveLength(26);
     expect(commandNames).toContain('auth');
     expect(commandNames).toContain('overview');
     expect(commandNames).toContain('demographics');
@@ -62,6 +62,7 @@ describe('CLI program', () => {
     expect(commandNames).toContain('data:subscriptions');
     expect(commandNames).toContain('data:activities');
     expect(commandNames).toContain('data:captions');
+    expect(commandNames).toContain('data:transcript');
     expect(commandNames).toContain('data:categories');
     expect(commandNames).toContain('data:i18n');
   });


### PR DESCRIPTION
## Summary
- YouTube innertube API를 활용하여 공개 영상의 자막(자동생성 포함)을 텍스트로 추출하는 `data:transcript` 커맨드 추가
- 공식 Data API `captions.download`는 자기 소유 영상만 지원하므로, 타인 영상의 자동생성 자막도 가져올 수 있는 timedtext 방식 채택
- 외부 패키지 추가 없이 Node.js 내장 fetch + 정규식 XML 파싱으로 구현

## 변경 사항
- `src/transcript.ts` — innertube API 호출, timedtext XML 파싱, 자막 추출 핵심 모듈
- `src/transcript.test.ts` — 15개 테스트 (extractCaptionTracks, selectTrack, parseTimedTextXml, fetchTranscript, listAvailableTracks)
- `src/commands/data-transcript.ts` — CLI 커맨드 핸들러 (json/text 포맷 지원)
- `src/commands/data-transcript.test.ts` — 4개 테스트 (옵션 전달, 출력 검증)
- `src/index.ts` — `data:transcript` 커맨드 등록
- `src/index.test.ts` — 서브커맨드 개수 25→26 업데이트
- `README.md` — `data:transcript` 사용법 문서 추가

## 사용법
```bash
# JSON 출력 (타임스탬프 포함)
parrotube data:transcript --video-id dQw4w9WgXcQ

# 특정 언어 자막
parrotube data:transcript --video-id dQw4w9WgXcQ --lang ko

# 순수 텍스트만 출력
parrotube data:transcript --video-id dQw4w9WgXcQ --format text
```

## Test plan
- [x] `bun test src/transcript.test.ts` — 15개 통과
- [x] `bun test src/commands/data-transcript.test.ts` — 4개 통과
- [ ] CI 전체 테스트 통과 확인

https://claude.ai/code/session_01SfGj3kjVu9VXpodF7ZExGr