### PR TITLE
fix: publish 워크플로 npm ci → npm install 수정

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm ci
+      - run: npm install --ignore-scripts
       - run: npm run build
 
       - name: Check if version changed


### PR DESCRIPTION
## Summary
- `publish` 워크플로에서 `npm ci`가 `package-lock.json` 부재로 실패하는 문제 수정
- 프로젝트가 Bun을 사용하여 `bun.lock`만 존재하므로 `npm install --ignore-scripts`로 변경

## Test plan
- [ ] CI publish 잡이 `npm install` 단계를 정상 통과하는지 확인

https://claude.ai/code/session_01SfGj3kjVu9VXpodF7ZExGr