### PR TITLE
fix: npm publish 404 에러 수정 + v0.3.0 배포

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,8 +47,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm install --ignore-scripts
-      - run: npm run build
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run build
 
       - name: Check if version changed
         id: version


### PR DESCRIPTION
## Summary
- npm publish 404 에러 수정: publish 잡 의존성 설치를 `npm install` → `bun install`로 변경
- `package.json` + `src/index.ts` 버전 `0.2.0` → `0.3.0` 업데이트
- 버전업 리마인더 추가 (AGENTS.md 규칙 + CI 체크)

## 원인 분석
`npm install --ignore-scripts`가 `package-lock.json` 없는 환경에서 실행되면서 `actions/setup-node`가 설정한 `.npmrc` auth 토큰과 충돌하여 `npm publish`가 404 에러 발생.

## 수정
- publish 잡에서 `bun install` + `bun run build` 사용 (`.npmrc` 간섭 없음)
- `actions/setup-node`는 npm publish용 auth 설정 전용으로만 유지

## Test plan
- [ ] CI 테스트 통과
- [ ] 머지 후 npm publish 0.3.0 배포 성공 확인

https://claude.ai/code/session_01SfGj3kjVu9VXpodF7ZExGr