### PR TITLE
fix: npm Trusted Publisher (OIDC) 방식으로 publish 전환

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm to support Trusted Publisher
+        run: npm install -g npm@latest
+
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - run: bun run build
@@ -63,18 +66,6 @@ jobs:
           else
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
-
-      - name: Debug npm auth
-        run: |
-          echo "=== npm whoami ==="
-          npm whoami || echo "npm whoami failed - token may be invalid"
-          echo "=== npm view parrotube ==="
-          npm view parrotube versions --json || echo "npm view failed"
-          echo "=== npm config (registry + userconfig path) ==="
-          npm config get registry
-          npm config get userconfig
-          echo "=== .npmrc content (auth masked) ==="
-          cat "$NPM_CONFIG_USERCONFIG" 2>/dev/null | sed 's/_authToken=.*/_authToken=***MASKED***/' || echo ".npmrc not found"
 
       - name: Publish
         if: steps.version.outputs.changed == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,18 @@ jobs:
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Debug npm auth
+        run: |
+          echo "=== npm whoami ==="
+          npm whoami || echo "npm whoami failed - token may be invalid"
+          echo "=== npm view parrotube ==="
+          npm view parrotube versions --json || echo "npm view failed"
+          echo "=== npm config (registry + userconfig path) ==="
+          npm config get registry
+          npm config get userconfig
+          echo "=== .npmrc content (auth masked) ==="
+          cat "$NPM_CONFIG_USERCONFIG" 2>/dev/null | sed 's/_authToken=.*/_authToken=***MASKED***/' || echo ".npmrc not found"
+
       - name: Publish
         if: steps.version.outputs.changed == 'true'
         run: npm publish --provenance --access public

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,26 @@ import { output } from '../utils/formatter.js';
 output(result, options.format); // json 또는 table
 ```
 
+### Deployment (npm publish)
+
+배포는 `.github/workflows/publish.yml`에서 `main` 브랜치 푸시 시 자동 실행된다.
+
+**인증 방식: npm Trusted Publisher (OIDC)**
+- npm 패키지 설정이 `Require 2FA and disallow tokens`로 되어 있어 **토큰 기반 publish는 불가능**하다
+- npmjs.com의 패키지 Settings > Trusted Publisher에 이 레포(`devbrother2024/parrotube`)와 워크플로(`publish.yml`)가 등록되어 있다
+- GitHub Actions의 OIDC 토큰을 사용하여 npm에 인증한다
+
+**워크플로 필수 요건:**
+- `permissions: id-token: write` 필수 (OIDC 토큰 발급용)
+- npm **11.5.1 이상** 필수 (Trusted Publisher는 이 버전부터 지원) -- Node 22 기본 npm은 10.x이므로 `npm install -g npm@latest`로 업그레이드 필요
+- `NODE_AUTH_TOKEN` 환경변수를 **설정하지 않는다** (토큰이 disallow되어 있어 404 에러 발생)
+
+**주의 사항 (과거 트러블슈팅 기록):**
+- `npm publish` 시 `404 Not Found - PUT https://registry.npmjs.org/parrotube` 에러가 나면 OIDC fallback 실패를 의심한다
+- provenance 서명은 성공하는데 PUT만 실패하는 패턴이 특징
+- `actions/setup-node`의 `registry-url` 옵션은 유지하되, secrets에 토큰을 넣어두면 오히려 방해가 된다
+- `package.json` + `src/index.ts`의 version이 npmjs.com의 최신 버전과 다를 때만 publish 스텝이 실행된다
+
 ### Maintenance Policy
 규칙과 실제 코드 사이에 괴리가 발생하면 이 파일의 업데이트를 제안하라.
 


### PR DESCRIPTION
## Summary
npm publish 404 에러의 근본 원인을 찾아 수정합니다.

## 원인
npm 패키지 설정에서 **"Require two-factor authentication and disallow tokens (recommended)"** 옵션이 활성화되어 있어 **토큰 기반 publish가 비활성화**된 상태입니다. 대신 **Trusted Publisher (OIDC)**가 이미 설정되어 있습니다:
- Repository: `devbrother2024/parrotube`
- Workflow: `publish.yml`

기존 워크플로는 `NODE_AUTH_TOKEN`을 사용하려 했지만, 토큰이 disallow되어 있어 404 에러가 발생했습니다. 이때 provenance 서명은 성공하지만 최종 PUT 요청이 거부되는 특이한 패턴이 나타납니다.

## 해결
**OIDC Trusted Publisher 방식으로 전환**:
1. `npm install -g npm@latest` 스텝 추가 — Trusted Publisher는 **npm 11.5.1+** 필요 (Node 22 기본은 npm 10.x)
2. `id-token: write` 권한은 이미 설정되어 있으므로 OIDC 토큰 자동 사용
3. `NODE_AUTH_TOKEN`이 GitHub Secrets에 없으면 `actions/setup-node`가 `.npmrc`에 토큰을 주입하지 않아 OIDC로 자연스럽게 fallback
4. 이전 커밋의 디버그 스텝 제거

## 검증 방법
- 머지 후 Actions 로그에서 `npm publish` 성공 확인
- https://www.npmjs.com/package/parrotube 에서 `0.3.0` 버전 확인

## 참고
- [npm Trusted Publishers docs](https://docs.npmjs.com/trusted-publishers)
- npm 11.5.1+ 필요 (2025년 7월 릴리스)

https://claude.ai/code/session_01SfGj3kjVu9VXpodF7ZExGr