### PR TITLE
fix: Node 24로 업그레이드 (npm 11.x 기본 제공)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,11 +44,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Update npm to support Trusted Publisher
-        run: npm install -g npm@latest
 
       - uses: oven-sh/setup-bun@v2
       - run: bun install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,8 @@ output(result, options.format); // json 또는 table
 
 **워크플로 필수 요건:**
 - `permissions: id-token: write` 필수 (OIDC 토큰 발급용)
-- npm **11.5.1 이상** 필수 (Trusted Publisher는 이 버전부터 지원) -- Node 22 기본 npm은 10.x이므로 `npm install -g npm@latest`로 업그레이드 필요
+- npm **11.5.1 이상** 필수 (Trusted Publisher는 이 버전부터 지원) -- **Node 24 사용으로 해결** (Node 22 기본 npm은 10.x, Node 24는 기본 npm 11.x)
+- `npm install -g npm@latest`로 self-upgrade는 `MODULE_NOT_FOUND` 에러가 발생하므로 사용 금지. Node 버전으로 해결한다
 - `NODE_AUTH_TOKEN` 환경변수를 **설정하지 않는다** (토큰이 disallow되어 있어 404 에러 발생)
 
 **주의 사항 (과거 트러블슈팅 기록):**


### PR DESCRIPTION
## Summary
npm publish의 npm 버전 문제를 Node 24로 해결합니다.

## 문제
이전 PR의 `npm install -g npm@latest` 스텝이 self-upgrade 중 `MODULE_NOT_FOUND: promise-retry` 에러로 실패:
```
npm error Cannot find module 'promise-retry'
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/...
```

## 해결
**Node 22 → Node 24**로 업그레이드:
- Node 22: 기본 npm 10.x (Trusted Publisher 미지원)
- Node 24: 기본 **npm 11.x** (Trusted Publisher 지원 ✓)

별도의 npm 업그레이드 스텝이 필요 없어져 더 깔끔합니다.

## 변경 사항
- `.github/workflows/publish.yml`: `node-version: '22'` → `'24'`, `Update npm` 스텝 제거
- `AGENTS.md`: 이 해결 방법을 Deployment 섹션에 추가 (self-upgrade 금지, Node 버전으로 해결)

## Test plan
- [ ] 머지 후 `npm publish` 0.3.0 배포 성공 확인
- [ ] https://www.npmjs.com/package/parrotube 에서 0.3.0 확인

https://claude.ai/code/session_01SfGj3kjVu9VXpodF7ZExGr