### PR TITLE
fix: Innertube API 차단으로 고장난 자막 가져오기를 yt-dlp 기반으로 교체

### DIFF
--- a/.worklog/fix-23.md
+++ b/.worklog/fix-23.md
@@ -1,0 +1,32 @@
+## YouTube 자막 가져오기를 yt-dlp 기반으로 교체
+
+### 핵심 변경 사항
+
+- `src/transcript.ts`에서 Innertube WEB 클라이언트 직접 호출 방식을 yt-dlp subprocess + json3 fetch 방식으로 전면 교체
+- YouTube가 Innertube API에 PO Token을 요구하기 시작하면서 기존 방식이 완전히 고장남 (WEB → UNPLAYABLE, ANDROID → FAILED_PRECONDITION, timedtext → 빈 응답)
+- 외부 인터페이스(`TranscriptResult`, `CaptionTrack`, `TranscriptSegment`, `selectTrack`, `fetchTranscript`, `listAvailableTracks`)는 그대로 유지
+- 삭제: `extractCaptionTracks`, `parseTimedTextXml` (더 이상 사용 안 함)
+- 추가: `parseJson3Subtitles` (yt-dlp json3 포맷 파싱)
+- 테스트 전면 재작성: mock 대상을 `globalThis.fetch` → `node:child_process` + `fetch`로 변경
+- README에 yt-dlp 의존성 안내 추가
+
+### 테스트 결과
+
+- `bun test`: 132개 전체 통과 (transcript 16개 포함)
+- `bun run build`: tsc 컴파일 성공
+- E2E: `data:transcript --video-id dQw4w9WgXcQ` 영어/일본어 수동 자막 정상 출력
+- 한국어 자동 자막은 YouTube 429 레이트 리밋 (일시적, 코드 문제 아님)
+
+### 설계 결정
+
+- **yt-dlp `--dump-json` 1회 호출로 트랙 목록 + json3 URL 모두 추출** → 임시 파일 불필요, 메모리 내 처리
+- `node:child_process`의 `execFile` 콜백을 직접 Promise 래퍼로 감싸 사용 → `promisify`가 Bun mock에서 호환 문제 있어서
+- `CaptionTrack.baseUrl`에 json3 URL 저장 (디버깅용)
+- 수동 자막 우선, 자동 자막 나중에 배치 (기존 동작과 동일한 우선순위)
+
+## TODO
+### 배포
+- [ ] 버전 올리고 npm publish
+### 개선
+- [ ] json3 포맷이 없을 때 vtt/srv3 폴백 지원
+- [ ] table 포맷 출력 시 중첩 구조(segments) 플래트닝

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ YouTube Analytics CLI for AI agents and humans. Pull channel demographics, geogr
 
 **Works with:** Claude Code, Cursor, and any agent that can run shell commands.
 
+## Prerequisites
+
+- **Node.js** >= 18
+- **yt-dlp** — required for `data:transcript` command. [Install guide](https://github.com/yt-dlp/yt-dlp#installation)
+
 ## Installation
 
 ```bash
@@ -37,7 +42,7 @@ npx parrotube auth
 | **Data API** | data:comments, data:channel, data:videos, data:playlists, data:playlist-items, data:search, data:subscriptions, data:activities, data:captions, data:categories, data:i18n | Yes |
 | **No Auth** | data:transcript | **No** |
 
-`data:transcript` uses YouTube's innertube API and works without any authentication. All other commands require OAuth2 setup (see [Setup](#setup-one-time)).
+`data:transcript` uses [yt-dlp](https://github.com/yt-dlp/yt-dlp) to fetch subtitles and works without any authentication. All other commands require OAuth2 setup (see [Setup](#setup-one-time)).
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parrotube",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "YouTube Analytics CLI for AI agents and humans. Pull channel demographics, geography, traffic sources, device stats, and more.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export function createProgram(): Command {
   program
     .name('parrotube')
     .description('YouTube Analytics CLI for AI agents and humans\n\nCommands marked [no auth] work without authentication.')
-    .version('0.3.0')
+    .version('0.3.1')
     .option('-p, --period <value>', 'Shorthand period: 7d, 28d, 90d, 1y', '28d')
     .option('--start-date <YYYY-MM-DD>', 'Custom start date')
     .option('--end-date <YYYY-MM-DD>', 'Custom end date')

--- a/src/transcript.test.ts
+++ b/src/transcript.test.ts
@@ -1,11 +1,42 @@
 import { describe, expect, test, mock, afterEach, beforeEach } from 'bun:test';
 
-// mock global fetch before importing module
+// yt-dlp subprocess mock
+const mockExecFile = mock<
+  (cmd: string, args: string[], opts: Record<string, unknown>) => Promise<{ stdout: string; stderr: string }>
+>(() => Promise.resolve({ stdout: '', stderr: '' }));
+
+mock.module('node:child_process', () => ({
+  execFile: (
+    cmd: string,
+    args: string[],
+    opts: Record<string, unknown>,
+    cb: (err: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    mockExecFile(cmd, args, opts)
+      .then((r) => cb(null, r.stdout, r.stderr))
+      .catch((e) => cb(e, '', ''));
+  },
+}));
+
+// fetch mock for json3 URL
 const mockFetch = mock<(url: string | URL | Request, init?: RequestInit) => Promise<Response>>(() =>
   Promise.resolve(new Response('', { status: 200 })),
 );
 
 const originalFetch = globalThis.fetch;
+
+// yt-dlp --dump-json 샘플 응답
+function makeDumpJson(opts?: {
+  subtitles?: Record<string, Array<{ ext: string; url: string }>>;
+  automatic_captions?: Record<string, Array<{ ext: string; url: string }>>;
+}) {
+  return JSON.stringify({
+    id: 'test123',
+    title: 'Test Video',
+    subtitles: opts?.subtitles ?? {},
+    automatic_captions: opts?.automatic_captions ?? {},
+  });
+}
 
 describe('transcript', () => {
   beforeEach(() => {
@@ -15,51 +46,70 @@ describe('transcript', () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
     mockFetch.mockClear();
+    mockExecFile.mockClear();
   });
 
-  describe('extractCaptionTracks', () => {
-    test('playerResponse에서 captionTracks 배열을 추출한다', async () => {
-      const { extractCaptionTracks } = await import('./transcript');
-      const playerResponse = {
-        captions: {
-          playerCaptionsTracklistRenderer: {
-            captionTracks: [
-              {
-                baseUrl: 'https://www.youtube.com/timedtext?v=abc&lang=ko',
-                name: { simpleText: '한국어' },
-                languageCode: 'ko',
-                kind: 'asr',
-              },
-              {
-                baseUrl: 'https://www.youtube.com/timedtext?v=abc&lang=en',
-                name: { simpleText: 'English' },
-                languageCode: 'en',
-              },
-            ],
-          },
-        },
+  describe('parseJson3Subtitles', () => {
+    test('json3 events를 TranscriptSegment[]로 변환한다', async () => {
+      const { parseJson3Subtitles } = await import('./transcript');
+      const json3 = {
+        events: [
+          { tStartMs: 1400, dDurationMs: 1700, segs: [{ utf8: 'Hello' }] },
+          { tStartMs: 3100, dDurationMs: 2000, segs: [{ utf8: 'World' }] },
+        ],
       };
 
-      const tracks = extractCaptionTracks(playerResponse);
-      expect(tracks).toHaveLength(2);
-      expect(tracks[0]).toEqual({
-        languageCode: 'ko',
-        name: '한국어',
-        baseUrl: 'https://www.youtube.com/timedtext?v=abc&lang=ko',
-        kind: 'asr',
-      });
-      expect(tracks[1]).toEqual({
-        languageCode: 'en',
-        name: 'English',
-        baseUrl: 'https://www.youtube.com/timedtext?v=abc&lang=en',
-        kind: undefined,
-      });
+      const segments = parseJson3Subtitles(json3);
+      expect(segments).toHaveLength(2);
+      expect(segments[0]).toEqual({ text: 'Hello', start: 1.4, duration: 1.7 });
+      expect(segments[1]).toEqual({ text: 'World', start: 3.1, duration: 2 });
     });
 
-    test('captions가 없으면 빈 배열을 반환한다', async () => {
-      const { extractCaptionTracks } = await import('./transcript');
-      expect(extractCaptionTracks({})).toEqual([]);
-      expect(extractCaptionTracks({ captions: {} })).toEqual([]);
+    test('segs가 없는 이벤트는 스킵한다', async () => {
+      const { parseJson3Subtitles } = await import('./transcript');
+      const json3 = {
+        events: [
+          { tStartMs: 0, dDurationMs: 1000 }, // segs 없음
+          { tStartMs: 1000, dDurationMs: 500, segs: [{ utf8: 'Hello' }] },
+          { tStartMs: 1500, dDurationMs: 0 }, // segs 없음
+        ],
+      };
+
+      const segments = parseJson3Subtitles(json3);
+      expect(segments).toHaveLength(1);
+      expect(segments[0].text).toBe('Hello');
+    });
+
+    test('빈 events 배열이면 빈 배열을 반환한다', async () => {
+      const { parseJson3Subtitles } = await import('./transcript');
+      expect(parseJson3Subtitles({ events: [] })).toEqual([]);
+    });
+
+    test('여러 segs를 join한다', async () => {
+      const { parseJson3Subtitles } = await import('./transcript');
+      const json3 = {
+        events: [
+          {
+            tStartMs: 0,
+            dDurationMs: 2000,
+            segs: [{ utf8: 'Hello ' }, { utf8: 'World' }],
+          },
+        ],
+      };
+
+      const segments = parseJson3Subtitles(json3);
+      expect(segments[0].text).toBe('Hello World');
+    });
+
+    test('ms를 초 단위로 정확히 변환한다', async () => {
+      const { parseJson3Subtitles } = await import('./transcript');
+      const json3 = {
+        events: [{ tStartMs: 18600, dDurationMs: 3200, segs: [{ utf8: 'test' }] }],
+      };
+
+      const segments = parseJson3Subtitles(json3);
+      expect(segments[0].start).toBe(18.6);
+      expect(segments[0].duration).toBe(3.2);
     });
   });
 
@@ -88,9 +138,7 @@ describe('transcript', () => {
 
     test('해당 언어가 없으면 에러를 throw한다', async () => {
       const { selectTrack } = await import('./transcript');
-      const tracks = [
-        { languageCode: 'ko', name: '한국어', baseUrl: 'url-ko', kind: 'asr' },
-      ];
+      const tracks = [{ languageCode: 'ko', name: '한국어', baseUrl: 'url-ko', kind: 'asr' }];
 
       expect(() => selectTrack(tracks, 'ja')).toThrow();
     });
@@ -101,127 +149,56 @@ describe('transcript', () => {
     });
   });
 
-  describe('parseTimedTextXml', () => {
-    test('XML에서 TranscriptSegment 배열을 파싱한다', async () => {
-      const { parseTimedTextXml } = await import('./transcript');
-      const xml = `<?xml version="1.0" encoding="utf-8" ?>
-<transcript>
-  <text start="0" dur="3.5">Hello world</text>
-  <text start="3.5" dur="2.1">This is a test</text>
-</transcript>`;
-
-      const segments = parseTimedTextXml(xml);
-      expect(segments).toHaveLength(2);
-      expect(segments[0]).toEqual({ text: 'Hello world', start: 0, duration: 3.5 });
-      expect(segments[1]).toEqual({ text: 'This is a test', start: 3.5, duration: 2.1 });
-    });
-
-    test('HTML 엔티티를 디코딩한다', async () => {
-      const { parseTimedTextXml } = await import('./transcript');
-      const xml = `<transcript>
-  <text start="0" dur="1">Tom &amp; Jerry</text>
-  <text start="1" dur="1">It&#39;s fine</text>
-  <text start="2" dur="1">&lt;hello&gt;</text>
-  <text start="3" dur="1">&quot;quoted&quot;</text>
-</transcript>`;
-
-      const segments = parseTimedTextXml(xml);
-      expect(segments[0].text).toBe('Tom & Jerry');
-      expect(segments[1].text).toBe("It's fine");
-      expect(segments[2].text).toBe('<hello>');
-      expect(segments[3].text).toBe('"quoted"');
-    });
-
-    test('빈 XML이면 빈 배열을 반환한다', async () => {
-      const { parseTimedTextXml } = await import('./transcript');
-      expect(parseTimedTextXml('')).toEqual([]);
-      expect(parseTimedTextXml('<transcript></transcript>')).toEqual([]);
-    });
-
-    test('줄바꿈이 포함된 텍스트를 처리한다', async () => {
-      const { parseTimedTextXml } = await import('./transcript');
-      const xml = `<transcript>
-  <text start="0" dur="2">line one\nline two</text>
-</transcript>`;
-
-      const segments = parseTimedTextXml(xml);
-      expect(segments[0].text).toBe('line one\nline two');
-    });
-  });
-
   describe('fetchTranscript', () => {
-    test('innertube API를 호출하고 자막을 반환한다', async () => {
-      const playerResponse = {
-        captions: {
-          playerCaptionsTracklistRenderer: {
-            captionTracks: [
-              {
-                baseUrl: 'https://www.youtube.com/timedtext?v=test123&lang=ko',
-                name: { simpleText: '한국어 (자동 생성)' },
-                languageCode: 'ko',
-                kind: 'asr',
-              },
-            ],
-          },
+    test('yt-dlp로 자막을 가져와 반환한다', async () => {
+      const dumpJson = makeDumpJson({
+        subtitles: {
+          ko: [
+            { ext: 'json3', url: 'https://example.com/ko.json3' },
+            { ext: 'vtt', url: 'https://example.com/ko.vtt' },
+          ],
         },
-      };
+      });
 
-      const timedTextXml = `<transcript>
-  <text start="0" dur="3">안녕하세요</text>
-  <text start="3" dur="2">테스트입니다</text>
-</transcript>`;
+      mockExecFile.mockImplementationOnce(() => Promise.resolve({ stdout: dumpJson, stderr: '' }));
 
-      mockFetch
-        .mockImplementationOnce(() =>
-          Promise.resolve(new Response(JSON.stringify(playerResponse), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          })),
-        )
-        .mockImplementationOnce(() =>
-          Promise.resolve(new Response(timedTextXml, { status: 200 })),
-        );
+      const json3Data = JSON.stringify({
+        events: [
+          { tStartMs: 0, dDurationMs: 3000, segs: [{ utf8: '안녕하세요' }] },
+          { tStartMs: 3000, dDurationMs: 2000, segs: [{ utf8: '테스트입니다' }] },
+        ],
+      });
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve(new Response(json3Data, { status: 200 })),
+      );
 
       const { fetchTranscript } = await import('./transcript');
       const result = await fetchTranscript('test123');
 
       expect(result.videoId).toBe('test123');
       expect(result.language).toBe('ko');
-      expect(result.isAutoGenerated).toBe(true);
+      expect(result.isAutoGenerated).toBe(false);
       expect(result.segments).toHaveLength(2);
       expect(result.segments[0]).toEqual({ text: '안녕하세요', start: 0, duration: 3 });
     });
 
     test('지정한 언어의 자막을 가져온다', async () => {
-      const playerResponse = {
-        captions: {
-          playerCaptionsTracklistRenderer: {
-            captionTracks: [
-              {
-                baseUrl: 'https://www.youtube.com/timedtext?v=test123&lang=ko',
-                name: { simpleText: '한국어' },
-                languageCode: 'ko',
-                kind: 'asr',
-              },
-              {
-                baseUrl: 'https://www.youtube.com/timedtext?v=test123&lang=en',
-                name: { simpleText: 'English' },
-                languageCode: 'en',
-              },
-            ],
-          },
+      const dumpJson = makeDumpJson({
+        subtitles: {
+          ko: [{ ext: 'json3', url: 'https://example.com/ko.json3' }],
+          en: [{ ext: 'json3', url: 'https://example.com/en.json3' }],
         },
-      };
+      });
 
-      const timedTextXml = `<transcript><text start="0" dur="1">Hello</text></transcript>`;
-
-      mockFetch
-        .mockImplementationOnce(() =>
-          Promise.resolve(new Response(JSON.stringify(playerResponse), { status: 200 })),
-        )
-        .mockImplementationOnce(() =>
-          Promise.resolve(new Response(timedTextXml, { status: 200 })),
-        );
+      mockExecFile.mockImplementationOnce(() => Promise.resolve({ stdout: dumpJson, stderr: '' }));
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ events: [{ tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: 'Hello' }] }] }),
+            { status: 200 },
+          ),
+        ),
+      );
 
       const { fetchTranscript } = await import('./transcript');
       const result = await fetchTranscript('test123', 'en');
@@ -230,60 +207,80 @@ describe('transcript', () => {
       expect(result.isAutoGenerated).toBe(false);
     });
 
-    test('자막이 없는 영상이면 에러를 throw한다', async () => {
-      const playerResponse = { captions: {} };
+    test('자동 생성 자막을 가져온다', async () => {
+      const dumpJson = makeDumpJson({
+        automatic_captions: {
+          ko: [{ ext: 'json3', url: 'https://example.com/ko-auto.json3' }],
+        },
+      });
 
+      mockExecFile.mockImplementationOnce(() => Promise.resolve({ stdout: dumpJson, stderr: '' }));
       mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(new Response(JSON.stringify(playerResponse), { status: 200 })),
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ events: [{ tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: 'test' }] }] }),
+            { status: 200 },
+          ),
+        ),
       );
+
+      const { fetchTranscript } = await import('./transcript');
+      const result = await fetchTranscript('test123');
+
+      expect(result.isAutoGenerated).toBe(true);
+    });
+
+    test('자막이 없는 영상이면 에러를 throw한다', async () => {
+      const dumpJson = makeDumpJson({});
+      mockExecFile.mockImplementationOnce(() => Promise.resolve({ stdout: dumpJson, stderr: '' }));
 
       const { fetchTranscript } = await import('./transcript');
       await expect(fetchTranscript('no-captions')).rejects.toThrow();
     });
 
-    test('innertube API 호출 실패 시 에러를 throw한다', async () => {
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(new Response('', { status: 500 })),
+    test('yt-dlp 실행 실패 시 에러를 throw한다', async () => {
+      mockExecFile.mockImplementationOnce(() =>
+        Promise.reject(new Error('yt-dlp exited with code 1')),
       );
 
       const { fetchTranscript } = await import('./transcript');
       await expect(fetchTranscript('fail-video')).rejects.toThrow();
     });
+
+    test('yt-dlp 미설치 시 안내 메시지를 포함한 에러를 throw한다', async () => {
+      const err = new Error('spawn yt-dlp ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      mockExecFile.mockImplementationOnce(() => Promise.reject(err));
+
+      const { fetchTranscript } = await import('./transcript');
+      await expect(fetchTranscript('test123')).rejects.toThrow(/yt-dlp.*install/i);
+    });
   });
 
   describe('listAvailableTracks', () => {
-    test('사용 가능한 자막 트랙 목록을 반환한다', async () => {
-      const playerResponse = {
-        captions: {
-          playerCaptionsTracklistRenderer: {
-            captionTracks: [
-              {
-                baseUrl: 'https://www.youtube.com/timedtext?v=abc&lang=ko',
-                name: { simpleText: '한국어 (자동 생성)' },
-                languageCode: 'ko',
-                kind: 'asr',
-              },
-              {
-                baseUrl: 'https://www.youtube.com/timedtext?v=abc&lang=en',
-                name: { simpleText: 'English' },
-                languageCode: 'en',
-              },
-            ],
-          },
+    test('수동/자동 자막 트랙 목록을 반환한다', async () => {
+      const dumpJson = makeDumpJson({
+        subtitles: {
+          en: [{ ext: 'json3', url: 'https://example.com/en.json3' }],
+          ko: [{ ext: 'json3', url: 'https://example.com/ko.json3' }],
         },
-      };
+        automatic_captions: {
+          ja: [{ ext: 'json3', url: 'https://example.com/ja-auto.json3' }],
+        },
+      });
 
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(new Response(JSON.stringify(playerResponse), { status: 200 })),
-      );
+      mockExecFile.mockImplementationOnce(() => Promise.resolve({ stdout: dumpJson, stderr: '' }));
 
       const { listAvailableTracks } = await import('./transcript');
       const tracks = await listAvailableTracks('abc');
 
-      expect(tracks).toHaveLength(2);
-      expect(tracks[0].languageCode).toBe('ko');
-      expect(tracks[0].kind).toBe('asr');
-      expect(tracks[1].languageCode).toBe('en');
+      expect(tracks.length).toBe(3);
+      // 수동 자막이 먼저
+      const manual = tracks.filter((t) => t.kind !== 'asr');
+      const auto = tracks.filter((t) => t.kind === 'asr');
+      expect(manual.length).toBe(2);
+      expect(auto.length).toBe(1);
+      expect(auto[0].languageCode).toBe('ja');
     });
   });
 });

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -1,3 +1,18 @@
+import { execFile } from 'node:child_process';
+
+function execFileAsync(
+  cmd: string,
+  args: string[],
+  opts: { timeout?: number; maxBuffer?: number },
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, opts, (err, stdout, stderr) => {
+      if (err) return reject(err);
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
 export interface TranscriptSegment {
   text: string;
   start: number;
@@ -18,41 +33,94 @@ export interface TranscriptResult {
   segments: TranscriptSegment[];
 }
 
-interface InnertubePlayerResponse {
-  captions?: {
-    playerCaptionsTracklistRenderer?: {
-      captionTracks?: InnertubeTrack[];
-    };
-  };
+interface Json3Event {
+  tStartMs?: number;
+  dDurationMs?: number;
+  segs?: Array<{ utf8?: string }>;
 }
 
-interface InnertubeTrack {
-  baseUrl: string;
-  name: { simpleText: string };
-  languageCode: string;
-  kind?: string;
+interface Json3Response {
+  events?: Json3Event[];
 }
 
-const INNERTUBE_URL = 'https://www.youtube.com/youtubei/v1/player';
+interface SubtitleFormat {
+  ext: string;
+  url: string;
+}
 
-const INNERTUBE_CONTEXT = {
-  client: {
-    clientName: 'WEB',
-    clientVersion: '2.20240101.00.00',
-  },
-};
+interface YtDlpDumpJson {
+  subtitles?: Record<string, SubtitleFormat[]>;
+  automatic_captions?: Record<string, SubtitleFormat[]>;
+}
 
-export function extractCaptionTracks(playerResponse: Record<string, unknown>): CaptionTrack[] {
-  const captions = playerResponse.captions as InnertubePlayerResponse['captions'] | undefined;
-  const tracks = captions?.playerCaptionsTracklistRenderer?.captionTracks;
-  if (!tracks) return [];
+const YT_DLP_TIMEOUT_MS = 30_000;
 
-  return tracks.map((track) => ({
-    languageCode: track.languageCode,
-    name: track.name.simpleText,
-    baseUrl: track.baseUrl,
-    kind: track.kind,
-  }));
+async function runYtDlp(args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('yt-dlp', args, {
+      timeout: YT_DLP_TIMEOUT_MS,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return stdout;
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      throw new Error(
+        'yt-dlp is not installed. Install it: https://github.com/yt-dlp/yt-dlp#installation',
+      );
+    }
+    throw err;
+  }
+}
+
+function findJson3Url(formats: SubtitleFormat[]): string | undefined {
+  return formats.find((f) => f.ext === 'json3')?.url;
+}
+
+function buildTracksFromDumpJson(dumpJson: YtDlpDumpJson): CaptionTrack[] {
+  const tracks: CaptionTrack[] = [];
+
+  const subs = dumpJson.subtitles ?? {};
+  for (const [lang, formats] of Object.entries(subs)) {
+    const json3Url = findJson3Url(formats) ?? '';
+    tracks.push({
+      languageCode: lang,
+      name: lang,
+      baseUrl: json3Url,
+      kind: undefined,
+    });
+  }
+
+  const auto = dumpJson.automatic_captions ?? {};
+  for (const [lang, formats] of Object.entries(auto)) {
+    if (subs[lang]) continue;
+    const json3Url = findJson3Url(formats) ?? '';
+    tracks.push({
+      languageCode: lang,
+      name: `${lang} (auto)`,
+      baseUrl: json3Url,
+      kind: 'asr',
+    });
+  }
+
+  return tracks;
+}
+
+export function parseJson3Subtitles(json3: Json3Response): TranscriptSegment[] {
+  const events = json3.events ?? [];
+  const segments: TranscriptSegment[] = [];
+
+  for (const event of events) {
+    if (!event.segs || event.segs.length === 0) continue;
+
+    const text = event.segs.map((s) => s.utf8 ?? '').join('');
+    segments.push({
+      text,
+      start: (event.tStartMs ?? 0) / 1000,
+      duration: (event.dDurationMs ?? 0) / 1000,
+    });
+  }
+
+  return segments;
 }
 
 export function selectTrack(tracks: CaptionTrack[], lang?: string): CaptionTrack {
@@ -72,79 +140,53 @@ export function selectTrack(tracks: CaptionTrack[], lang?: string): CaptionTrack
   return tracks[0];
 }
 
-function decodeHtmlEntities(text: string): string {
-  return text
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#x27;/g, "'")
-    .replace(/&#(\d+);/g, (_match, code) => String.fromCharCode(parseInt(code, 10)));
-}
-
-export function parseTimedTextXml(xml: string): TranscriptSegment[] {
-  const segments: TranscriptSegment[] = [];
-  const regex = /<text\s+start="([^"]*?)"\s+dur="([^"]*?)"[^>]*>([\s\S]*?)<\/text>/g;
-
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(xml)) !== null) {
-    segments.push({
-      start: parseFloat(match[1]),
-      duration: parseFloat(match[2]),
-      text: decodeHtmlEntities(match[3]),
-    });
-  }
-
-  return segments;
-}
-
-async function fetchPlayerResponse(videoId: string): Promise<InnertubePlayerResponse> {
-  const response = await fetch(INNERTUBE_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      context: INNERTUBE_CONTEXT,
-      videoId,
-    }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch player response: ${response.status}`);
-  }
-
-  return (await response.json()) as InnertubePlayerResponse;
-}
-
-async function fetchTimedText(trackUrl: string): Promise<string> {
-  const response = await fetch(trackUrl);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch timed text: ${response.status}`);
-  }
-  return response.text();
+async function fetchDumpJson(videoId: string): Promise<YtDlpDumpJson> {
+  const stdout = await runYtDlp([
+    '--dump-json',
+    '--skip-download',
+    `https://www.youtube.com/watch?v=${videoId}`,
+  ]);
+  return JSON.parse(stdout) as YtDlpDumpJson;
 }
 
 export async function fetchTranscript(videoId: string, lang?: string): Promise<TranscriptResult> {
-  const playerResponse = await fetchPlayerResponse(videoId);
-  const tracks = extractCaptionTracks(playerResponse as Record<string, unknown>);
+  const dumpJson = await fetchDumpJson(videoId);
+  const tracks = buildTracksFromDumpJson(dumpJson);
 
   if (tracks.length === 0) {
     throw new Error(`No captions available for video: ${videoId}`);
   }
 
   const track = selectTrack(tracks, lang);
-  const xml = await fetchTimedText(track.baseUrl);
-  const segments = parseTimedTextXml(xml);
+
+  const isAuto = track.kind === 'asr';
+  const source = isAuto
+    ? dumpJson.automatic_captions ?? {}
+    : dumpJson.subtitles ?? {};
+  const formats = source[track.languageCode];
+  const json3Url = formats ? findJson3Url(formats) : undefined;
+
+  if (!json3Url) {
+    throw new Error(`No json3 subtitle format available for language: ${track.languageCode}`);
+  }
+
+  const response = await fetch(json3Url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch subtitle data: ${response.status}`);
+  }
+
+  const json3Data = (await response.json()) as Json3Response;
+  const segments = parseJson3Subtitles(json3Data);
 
   return {
     videoId,
     language: track.languageCode,
-    isAutoGenerated: track.kind === 'asr',
+    isAutoGenerated: isAuto,
     segments,
   };
 }
 
 export async function listAvailableTracks(videoId: string): Promise<CaptionTrack[]> {
-  const playerResponse = await fetchPlayerResponse(videoId);
-  return extractCaptionTracks(playerResponse as Record<string, unknown>);
+  const dumpJson = await fetchDumpJson(videoId);
+  return buildTracksFromDumpJson(dumpJson);
 }


### PR DESCRIPTION
Resolved #23

## Summary

YouTube가 Innertube WEB 클라이언트에 PO Token을 요구하기 시작하면서 `data:transcript` 커맨드가 완전히 고장남. `src/transcript.ts`의 내부 구현을 yt-dlp subprocess + json3 fetch 방식으로 교체하여 자막 추출 기능을 복구한다.

## Changes

- `src/transcript.ts`: Innertube 직접 호출(fetchPlayerResponse, fetchTimedText) 제거 → yt-dlp `--dump-json` subprocess 호출 + json3 URL fetch 방식으로 교체
- `src/transcript.test.ts`: mock 대상을 `node:child_process` + `globalThis.fetch`로 전면 재작성 (16개 테스트)
- `README.md`: Prerequisites 섹션에 yt-dlp 외부 의존성 안내 추가
- `package.json`, `src/index.ts`: 버전 0.3.0 → 0.3.1

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- `bun test`: 132개 전체 통과 (transcript 16개 포함)
- `bun run build`: tsc 컴파일 성공
- E2E: `bun run dev data:transcript --video-id dQw4w9WgXcQ` — 영어/일본어 수동 자막 정상 출력 확인

## Checklist

- [x] I have tested this change locally
- [x] I have updated documentation if needed
- [x] This change does not introduce security vulnerabilities