### PR TITLE
feat: 자막 업로드 커맨드를 추가하라

### DIFF
--- a/.worklog/feature-29.md
+++ b/.worklog/feature-29.md
@@ -1,0 +1,13 @@
+# Feature 29: 자막 업로드 커맨드 추가
+
+## Summary
+
+- Added `data:captions:upload` for YouTube caption track uploads.
+- Added `youtube.force-ssl` OAuth scope validation and reauthorization guidance.
+- Added tests for API wrapper, command action, auth scope handling, and CLI registration.
+
+## Verification
+
+- `bun test` passed: 138 pass, 0 fail.
+- `bun run build` passed.
+- `bun run dev data:captions:upload --help` showed the expected command options.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ npx parrotube auth
 | Category | Commands | Auth Required |
 |----------|----------|:---:|
 | **Analytics** | overview, demographics, geography, traffic, devices, revenue, sharing, top-videos, time-series, search-terms, video, query, report | Yes |
-| **Data API** | data:comments, data:channel, data:videos, data:playlists, data:playlist-items, data:search, data:subscriptions, data:activities, data:captions, data:categories, data:i18n | Yes |
+| **Data API** | data:comments, data:channel, data:videos, data:playlists, data:playlist-items, data:search, data:subscriptions, data:activities, data:captions, data:captions:upload, data:categories, data:i18n | Yes |
 | **No Auth** | data:transcript | **No** |
 
-`data:transcript` uses [yt-dlp](https://github.com/yt-dlp/yt-dlp) to fetch subtitles and works without any authentication. All other commands require OAuth2 setup (see [Setup](#setup-one-time)).
+`data:transcript` uses [yt-dlp](https://github.com/yt-dlp/yt-dlp) to fetch subtitles and works without any authentication. All other commands require OAuth2 setup (see [Setup](#setup-one-time)). If you authenticated before `data:captions:upload` existed, run `parrotube auth` again so the token includes caption upload permissions.
 
 ## Commands
 
@@ -243,6 +243,17 @@ List captions for a video.
 ```bash
 parrotube data:captions --video-id dQw4w9WgXcQ
 ```
+
+### data:captions:upload
+
+Upload a timed caption track for a video. The upload is public by default; add `--draft` to keep the track non-public while you review it.
+
+```bash
+parrotube data:captions:upload --video-id dQw4w9WgXcQ --file ./captions.vtt --language ko --name "Korean captions"
+parrotube data:captions:upload --video-id dQw4w9WgXcQ --file ./captions.srt --language en --name "English captions" --draft
+```
+
+This command uses YouTube Data API `captions.insert`, which costs 400 quota units per upload and accepts files up to 100MB. Existing OAuth tokens may only have read scopes; run `parrotube auth` again if the command asks for reauthorization.
 
 ### data:transcript (no auth required)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parrotube",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "YouTube Analytics CLI for AI agents and humans. Pull channel demographics, geography, traffic sources, device stats, and more.",
   "type": "module",
   "bin": {

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -97,13 +97,22 @@ describe('loadToken / saveToken', () => {
 });
 
 describe('SCOPES', () => {
-  test('yt-analytics.readonly와 youtube.readonly 포함', async () => {
-    const { SCOPES } = await import('./auth');
+  test('yt-analytics.readonly, youtube.readonly, youtube.force-ssl 포함', async () => {
+    const { SCOPES, YOUTUBE_FORCE_SSL_SCOPE } = await import('./auth');
     expect(SCOPES).toContain(
       'https://www.googleapis.com/auth/yt-analytics.readonly',
     );
     expect(SCOPES).toContain(
       'https://www.googleapis.com/auth/youtube.readonly',
     );
+    expect(SCOPES).toContain(YOUTUBE_FORCE_SSL_SCOPE);
+  });
+
+  test('requireTokenScope은 누락된 scope에 대해 재인증 안내 에러를 던진다', async () => {
+    const { requireTokenScope, YOUTUBE_FORCE_SSL_SCOPE } = await import('./auth');
+
+    expect(() =>
+      requireTokenScope(FAKE_TOKEN, YOUTUBE_FORCE_SSL_SCOPE, 'data:captions:upload'),
+    ).toThrow('Run `parrotube auth` again');
   });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -12,7 +12,11 @@ const TOKEN_PATH = path.join(CONFIG_DIR, 'token.json');
 export const SCOPES = [
   'https://www.googleapis.com/auth/yt-analytics.readonly',
   'https://www.googleapis.com/auth/youtube.readonly',
+  'https://www.googleapis.com/auth/youtube.force-ssl',
 ];
+
+export const YOUTUBE_FORCE_SSL_SCOPE =
+  'https://www.googleapis.com/auth/youtube.force-ssl';
 
 interface ClientSecretFile {
   installed: {
@@ -39,6 +43,41 @@ export function loadToken(): Record<string, unknown> | null {
 export function saveToken(token: Record<string, unknown>): void {
   fs.mkdirSync(CONFIG_DIR, { recursive: true });
   fs.writeFileSync(TOKEN_PATH, JSON.stringify(token, null, 2));
+}
+
+function getTokenScopes(token: Record<string, unknown> | null): string[] {
+  if (!token) return [];
+
+  const scope = token.scope;
+  if (typeof scope === 'string') {
+    return scope.split(/\s+/).filter(Boolean);
+  }
+
+  if (Array.isArray(scope)) {
+    return scope.filter((value): value is string => typeof value === 'string');
+  }
+
+  return [];
+}
+
+export function tokenHasScope(
+  token: Record<string, unknown> | null,
+  requiredScope: string,
+): boolean {
+  return getTokenScopes(token).includes(requiredScope);
+}
+
+export function requireTokenScope(
+  token: Record<string, unknown> | null,
+  requiredScope: string,
+  commandName: string,
+): void {
+  if (tokenHasScope(token, requiredScope)) return;
+
+  throw new Error(
+    `${commandName} requires OAuth scope ${requiredScope}. ` +
+      'Run `parrotube auth` again to reauthorize.',
+  );
 }
 
 export async function authenticate(): Promise<void> {

--- a/src/commands/data-captions-upload.test.ts
+++ b/src/commands/data-captions-upload.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test, mock, spyOn, afterEach } from 'bun:test';
+
+const mockUploadCaption = mock(() =>
+  Promise.resolve({
+    id: 'caption-uploaded',
+    snippet: {
+      videoId: 'vid-123',
+      language: 'ko',
+      name: 'Korean captions',
+      isDraft: false,
+    },
+  }),
+);
+
+mock.module('../data-api', () => ({ uploadCaption: mockUploadCaption }));
+
+describe('dataCaptionsUploadAction', () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  afterEach(() => {
+    consoleSpy?.mockRestore();
+    mockUploadCaption.mockClear();
+  });
+
+  test('필수 옵션과 draft 기본값을 uploadCaption에 전달한다', async () => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    const { dataCaptionsUploadAction } = await import('./data-captions-upload');
+
+    await dataCaptionsUploadAction({} as never, {
+      format: 'json',
+      videoId: 'vid-123',
+      file: './captions.vtt',
+      language: 'ko',
+      name: 'Korean captions',
+      draft: false,
+    });
+
+    expect(mockUploadCaption).toHaveBeenCalledWith({
+      auth: {},
+      videoId: 'vid-123',
+      filePath: './captions.vtt',
+      language: 'ko',
+      name: 'Korean captions',
+      isDraft: false,
+    });
+  });
+
+  test('draft 옵션을 true로 전달한다', async () => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    const { dataCaptionsUploadAction } = await import('./data-captions-upload');
+
+    await dataCaptionsUploadAction({} as never, {
+      format: 'json',
+      videoId: 'vid-123',
+      file: './captions.vtt',
+      language: 'ko',
+      name: 'Korean captions',
+      draft: true,
+    });
+
+    expect(mockUploadCaption).toHaveBeenCalledWith(
+      expect.objectContaining({ isDraft: true }),
+    );
+  });
+
+  test('json 출력은 caption resource를 그대로 출력한다', async () => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    const { dataCaptionsUploadAction } = await import('./data-captions-upload');
+
+    await dataCaptionsUploadAction({} as never, {
+      format: 'json',
+      videoId: 'vid-123',
+      file: './captions.vtt',
+      language: 'ko',
+      name: 'Korean captions',
+      draft: false,
+    });
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as {
+      id: string;
+    };
+    expect(parsed.id).toBe('caption-uploaded');
+  });
+});

--- a/src/commands/data-captions-upload.ts
+++ b/src/commands/data-captions-upload.ts
@@ -1,0 +1,33 @@
+import type { OAuth2Client } from 'google-auth-library';
+import { uploadCaption } from '../data-api.js';
+import { output } from '../utils/formatter.js';
+
+interface ActionOptions {
+  format: string;
+  videoId: string;
+  file: string;
+  language: string;
+  name: string;
+  draft: boolean;
+}
+
+export async function dataCaptionsUploadAction(
+  auth: OAuth2Client,
+  options: ActionOptions,
+): Promise<void> {
+  const result = await uploadCaption({
+    auth,
+    videoId: options.videoId,
+    filePath: options.file,
+    language: options.language,
+    name: options.name,
+    isDraft: options.draft,
+  });
+
+  if (options.format === 'table') {
+    output({ items: [result] }, options.format);
+    return;
+  }
+
+  output(result, options.format);
+}

--- a/src/data-api.test.ts
+++ b/src/data-api.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test, mock, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 const mockCommentThreadsList = mock(() =>
   Promise.resolve({
@@ -153,6 +156,20 @@ const mockCaptionsList = mock(() =>
   }),
 );
 
+const mockCaptionsInsert = mock(() =>
+  Promise.resolve({
+    data: {
+      id: 'caption-uploaded',
+      snippet: {
+        videoId: 'video-1',
+        language: 'ko',
+        name: 'Korean captions',
+        isDraft: false,
+      },
+    },
+  }),
+);
+
 const mockVideoCategoriesList = mock(() =>
   Promise.resolve({
     data: {
@@ -193,7 +210,7 @@ mock.module('googleapis', () => ({
       search: { list: mockSearchList },
       subscriptions: { list: mockSubscriptionsList },
       activities: { list: mockActivitiesList },
-      captions: { list: mockCaptionsList },
+      captions: { list: mockCaptionsList, insert: mockCaptionsInsert },
       videoCategories: { list: mockVideoCategoriesList },
       i18nRegions: { list: mockI18nRegionsList },
       i18nLanguages: { list: mockI18nLanguagesList },
@@ -212,6 +229,7 @@ describe('data-api', () => {
     mockSubscriptionsList.mockClear();
     mockActivitiesList.mockClear();
     mockCaptionsList.mockClear();
+    mockCaptionsInsert.mockClear();
     mockVideoCategoriesList.mockClear();
     mockI18nRegionsList.mockClear();
     mockI18nLanguagesList.mockClear();
@@ -452,6 +470,67 @@ describe('data-api', () => {
       }),
     );
     expect(result.items[0].snippet.language).toBe('ko');
+  });
+
+  test('uploadCaption - 자막 파일과 metadata를 captions.insert로 전달', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'parrotube-caption-'));
+    const captionPath = path.join(tmpDir, 'captions.vtt');
+    fs.writeFileSync(captionPath, 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHello\n');
+
+    const { uploadCaption } = await import('./data-api');
+    const fakeAuth = {} as never;
+
+    const result = await uploadCaption({
+      auth: fakeAuth,
+      videoId: 'video-1',
+      filePath: captionPath,
+      language: 'ko',
+      name: 'Korean captions',
+      isDraft: false,
+    });
+
+    expect(mockCaptionsInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        part: ['snippet'],
+        requestBody: {
+          snippet: {
+            videoId: 'video-1',
+            language: 'ko',
+            name: 'Korean captions',
+            isDraft: false,
+          },
+        },
+        media: expect.objectContaining({
+          mimeType: 'application/octet-stream',
+        }),
+      }),
+    );
+    const request = mockCaptionsInsert.mock.calls[0]?.[0] as {
+      media?: { body?: unknown };
+    };
+    expect(request.media?.body).toBeTruthy();
+    expect(result.id).toBe('caption-uploaded');
+  });
+
+  test('uploadCaption - 100MB 초과 파일은 업로드 전 거부', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'parrotube-caption-'));
+    const captionPath = path.join(tmpDir, 'large.vtt');
+    fs.writeFileSync(captionPath, '');
+    fs.truncateSync(captionPath, 100 * 1024 * 1024 + 1);
+
+    const { uploadCaption } = await import('./data-api');
+
+    await expect(
+      uploadCaption({
+        auth: {} as never,
+        videoId: 'video-1',
+        filePath: captionPath,
+        language: 'ko',
+        name: 'Large captions',
+        isDraft: false,
+      }),
+    ).rejects.toThrow('Caption file must be 100MB or smaller');
+    expect(mockCaptionsInsert).not.toHaveBeenCalled();
   });
 
   test('listVideoCategories - regionCode로 호출', async () => {

--- a/src/data-api.ts
+++ b/src/data-api.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { google } from 'googleapis';
 import type { OAuth2Client } from 'google-auth-library';
 
@@ -234,6 +235,65 @@ export async function listCaptions(params: ListCaptionsParams): Promise<DataApiR
     videoId: params.videoId,
   });
   return response.data as DataApiResult;
+}
+
+const MAX_CAPTION_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+
+export interface UploadCaptionParams {
+  auth: OAuth2Client;
+  videoId: string;
+  filePath: string;
+  language: string;
+  name: string;
+  isDraft: boolean;
+}
+
+export interface CaptionResource {
+  id?: string;
+  snippet?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+function validateCaptionFile(filePath: string): void {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(filePath);
+  } catch {
+    throw new Error(`Caption file not found: ${filePath}`);
+  }
+
+  if (!stat.isFile()) {
+    throw new Error(`Caption path must be a file: ${filePath}`);
+  }
+
+  if (stat.size > MAX_CAPTION_FILE_SIZE_BYTES) {
+    throw new Error('Caption file must be 100MB or smaller');
+  }
+}
+
+export async function uploadCaption(
+  params: UploadCaptionParams,
+): Promise<CaptionResource> {
+  validateCaptionFile(params.filePath);
+
+  const yt = getYouTubeClient(params.auth);
+  const response = await yt.captions.insert({
+    part: ['snippet'],
+    requestBody: {
+      snippet: {
+        videoId: params.videoId,
+        language: params.language,
+        name: params.name,
+        isDraft: params.isDraft,
+      },
+    },
+    media: {
+      mimeType: 'application/octet-stream',
+      body: fs.createReadStream(params.filePath),
+    },
+  });
+
+  return response.data as CaptionResource;
 }
 
 // ---------- Video Categories ----------

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -33,12 +33,12 @@ describe('CLI program', () => {
     expect(help).toContain('--format');
   });
 
-  test('서브커맨드 26개 등록 (analytics + data api)', async () => {
+  test('서브커맨드 27개 등록 (analytics + data api)', async () => {
     const { createProgram } = await import('./index');
     const program = createProgram();
 
     const commandNames = program.commands.map((c) => c.name());
-    expect(commandNames).toHaveLength(26);
+    expect(commandNames).toHaveLength(27);
     expect(commandNames).toContain('auth');
     expect(commandNames).toContain('overview');
     expect(commandNames).toContain('demographics');
@@ -62,6 +62,7 @@ describe('CLI program', () => {
     expect(commandNames).toContain('data:subscriptions');
     expect(commandNames).toContain('data:activities');
     expect(commandNames).toContain('data:captions');
+    expect(commandNames).toContain('data:captions:upload');
     expect(commandNames).toContain('data:transcript');
     expect(commandNames).toContain('data:categories');
     expect(commandNames).toContain('data:i18n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,13 @@
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
-import { authenticate, getAuthClient } from './auth.js';
+import {
+  authenticate,
+  getAuthClient,
+  loadToken,
+  requireTokenScope,
+  YOUTUBE_FORCE_SSL_SCOPE,
+} from './auth.js';
 import { resolveDates } from './utils/date.js';
 import { overviewAction } from './commands/overview.js';
 import { demographicsAction } from './commands/demographics.js';
@@ -27,6 +33,7 @@ import { dataSearchAction } from './commands/data-search.js';
 import { dataSubscriptionsAction } from './commands/data-subscriptions.js';
 import { dataActivitiesAction } from './commands/data-activities.js';
 import { dataCaptionsAction } from './commands/data-captions.js';
+import { dataCaptionsUploadAction } from './commands/data-captions-upload.js';
 import { dataTranscriptAction } from './commands/data-transcript.js';
 import { dataCategoriesAction } from './commands/data-categories.js';
 import { dataI18nAction } from './commands/data-i18n.js';
@@ -37,7 +44,7 @@ export function createProgram(): Command {
   program
     .name('parrotube')
     .description('YouTube Analytics CLI for AI agents and humans\n\nCommands marked [no auth] work without authentication.')
-    .version('0.3.1')
+    .version('0.4.0')
     .option('-p, --period <value>', 'Shorthand period: 7d, 28d, 90d, 1y', '28d')
     .option('--start-date <YYYY-MM-DD>', 'Custom start date')
     .option('--end-date <YYYY-MM-DD>', 'Custom end date')
@@ -304,6 +311,32 @@ export function createProgram(): Command {
       await dataCaptionsAction(auth, {
         format: opts.format,
         videoId: cmdOpts.videoId,
+      });
+    });
+
+  program
+    .command('data:captions:upload')
+    .description('Upload a caption track for a video')
+    .requiredOption('--video-id <id>', 'YouTube video ID')
+    .requiredOption('--file <path>', 'Caption file path')
+    .requiredOption('--language <code>', 'Caption language code (e.g. ko, en)')
+    .requiredOption('--name <name>', 'Caption track name')
+    .option('--draft', 'Upload as a non-public draft')
+    .action(async (cmdOpts) => {
+      const opts = program.opts();
+      requireTokenScope(
+        loadToken(),
+        YOUTUBE_FORCE_SSL_SCOPE,
+        'data:captions:upload',
+      );
+      const auth = await getAuthClient();
+      await dataCaptionsUploadAction(auth, {
+        format: opts.format,
+        videoId: cmdOpts.videoId,
+        file: cmdOpts.file,
+        language: cmdOpts.language,
+        name: cmdOpts.name,
+        draft: cmdOpts.draft ?? false,
       });
     });
 


### PR DESCRIPTION
Resolved #29

## Summary

YouTube Data API captions.insert 기반의 자막 업로드 커맨드를 추가합니다.

## Changes

- data:captions:upload 커맨드를 추가하고 --video-id, --file, --language, --name, --draft 옵션을 지원합니다.
- uploadCaption API 래퍼에서 자막 파일 존재 여부, 일반 파일 여부, 100MB 제한을 검증한 뒤 media upload를 수행합니다.
- youtube.force-ssl OAuth scope와 기존 토큰 재인증 안내를 추가합니다.
- README에 새 커맨드, quota 400 units, 100MB 제한, 재인증 안내를 문서화하고 버전을 0.4.0으로 올립니다.
- API wrapper, command action, auth scope, CLI 등록 테스트를 추가합니다.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Infrastructure/configuration change

## Testing

- bun test
- bun run build
- bun run dev data:captions:upload --help

## Checklist

- [x] I have tested this change locally
- [x] I have updated documentation if needed
- [x] This change does not introduce security vulnerabilities
